### PR TITLE
Update test-and-lint.yml

### DIFF
--- a/.github/workflows/test-and-lint.yml
+++ b/.github/workflows/test-and-lint.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3
@@ -32,9 +32,7 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 gyver --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 gyver --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        ruff check --output-format=github gyver
     - name: Test with pytest
       run: |
         pytest tests


### PR DESCRIPTION
## Summary by Sourcery

Update Python versions used in CI to 3.10, 3.11, and 3.12. Replace flake8 with ruff.

CI:
- Update CI to use Python 3.10, 3.11, and 3.12.
- Replace flake8 with ruff.